### PR TITLE
ci(base image): Update base image to 2.6.0-rc.2

### DIFF
--- a/.github/workflows/generator.yml
+++ b/.github/workflows/generator.yml
@@ -19,7 +19,7 @@ jobs:
 
     environment: ${{ github.event.client_payload.environment }}
     container:
-      image: technologiestiftung/qtrees-vectortiles-generator-base:2.5
+      image: technologiestiftung/qtrees-vectortiles-generator-base:2.6.0-rc.2
       credentials:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/test-release-build.yml
+++ b/.github/workflows/test-release-build.yml
@@ -13,7 +13,7 @@ env:
   POSTGRES_MATERIALIZE_VIEW_NAME: "vector_tiles"
   POSTGREST_API_URL: "http://postgrest:3000"
   GEOJSON_OUTPUT_FILENAME: "out.full.geojson"
-  DEFAULT_BASE_IMAGE: technologiestiftung/qtrees-vectortiles-generator-base:2.5
+  DEFAULT_BASE_IMAGE: technologiestiftung/qtrees-vectortiles-generator-base:2.6.0-rc.2
 on:
   push:
     branches: [main, staging]
@@ -61,7 +61,7 @@ jobs:
     if: "!contains(github.event.head_commit.message, 'skip ci')"
     runs-on: ubuntu-latest
     container:
-      image: technologiestiftung/qtrees-vectortiles-generator-base:2.5
+      image: technologiestiftung/qtrees-vectortiles-generator-base:2.6.0-rc.2
     services:
       postgrest:
         image: postgrest/postgrest:v10.1.2


### PR DESCRIPTION
This PR updates the base image used in all docker actions (generator, tests) to 2.6.0-rc.2

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203752264369343